### PR TITLE
add testthat to package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,3 +11,5 @@ Depends: eiPack, methods, tmvtnorm,  foreach, ggplot2, ei, RCurl, RJSONIO, sjmis
 Imports: data.table, ucminf, R.utils, mvtnorm, msm, mnormt, cubature, ellipse, plotrix, plyr, tidyr, magrittr, stringr, mcmcse 
 NeedsCompilation: no
 Packaged: 2015-12-27 01:17:08 UTC; lorencollingwood
+Suggests: 
+    testthat

--- a/eiCompare.Rproj
+++ b/eiCompare.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(eiCompare)
+
+test_check("eiCompare")


### PR DESCRIPTION
Adding [unit testing infrastructure](https://r-pkgs.org/tests.html) to the package. Can be used to create unit tests for old functions and so that new features can be implemented alongside unit tests.

I am submitting this pull request because I want to begin building unit tests for new features.

Perhaps I am moving too quickly and we ought to first open a discussion about unit tests. If so, please let me know. 