### PR TITLE
add first test

### DIFF
--- a/tests/testthat/test_ei_est_gen_errors.R
+++ b/tests/testthat/test_ei_est_gen_errors.R
@@ -1,0 +1,5 @@
+context("ei_est_gen error handling")
+
+testthat::test_that("ei_est_gen returns error when called without parameters", {
+  testthat::expect_error(ei_est_gen())
+})


### PR DESCRIPTION
To resolve #10, adding a trivial first test to expect an error when ei_est_gen() is called without parameters.