### PR TITLE
Density voter choice plot color matching

### DIFF
--- a/R/od_plot_create.R
+++ b/R/od_plot_create.R
@@ -47,9 +47,9 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
   names(cols) <- c(gsub("pct_", "", cand_pair[1]), gsub("pct_", "", cand_pair[2]))
 
 
-  densplot <- ggplot2::ggplot(dens_data_sub, ggplot2::aes(x = value, fill = Candidate)) +
+  densplot <- ggplot2::ggplot(dens_data_sub, ggplot2::aes(x = value, fill = factor(Candidate))) +
     # Set colors according to candidate
-    scale_fill_manual(values = cols) +
+    scale_fill_manual(values = cols, aesthetics = c("colour", "fill")) +
     # Add titles
     ggplot2::ggtitle(paste0(
       gsub("pct_", "", cand_pair[1]), " vs ",
@@ -60,7 +60,7 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
     ggplot2::xlab("Percent of vote") +
     ggplot2::ylab("Density") +
     ggplot2::geom_density(
-      alpha = 0.5, ggplot2::aes(x = value * 100, y = ..scaled.., color = Candidate),
+      alpha = 0.5, ggplot2::aes(x = value * 100, y = ..scaled.., colour = factor(Candidate)),
       adjust = 2
     ) +
     # Add vertical line for halfway

--- a/R/od_plot_create.R
+++ b/R/od_plot_create.R
@@ -46,6 +46,12 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
   )
   names(cols) <- c(gsub("pct_", "", cand_pair[1]), gsub("pct_", "", cand_pair[2]))
 
+  # factor
+  dens_data_sub$Candidate <- factor(dens_data_sub$Candidate,
+    levels = gsub("pct_", "", cand_pair),
+    ordered = TRUE
+  )
+
 
   densplot <- ggplot2::ggplot(dens_data_sub, ggplot2::aes(x = value, fill = Candidate)) +
     # Set colors according to candidate

--- a/R/od_plot_create.R
+++ b/R/od_plot_create.R
@@ -40,11 +40,13 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
   overlap_point <- overlap_out$xpoints$`X1-X2`[[1]]
 
   # colors
-  cols <- c(
-    cand_colors[gsub("pct_", "", cand_pair[1])],
-    cand_colors[gsub("pct_", "", cand_pair[2])]
+  cols <- setNames(
+    c(
+      cand_colors[gsub("pct_", "", cand_pair[1])][[1]],
+      cand_colors[gsub("pct_", "", cand_pair[2])][[1]]
+    ),
+    c(gsub("pct_", "", cand_pair[1]), gsub("pct_", "", cand_pair[2]))
   )
-  names(cols) <- c(gsub("pct_", "", cand_pair[1]), gsub("pct_", "", cand_pair[2]))
 
   # factor
   dens_data_sub$Candidate <- factor(dens_data_sub$Candidate,

--- a/R/od_plot_create.R
+++ b/R/od_plot_create.R
@@ -49,7 +49,7 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
 
   densplot <- ggplot2::ggplot(dens_data_sub, ggplot2::aes(x = value, fill = Candidate)) +
     # Set colors according to candidate
-    scale_fill_manual(values = cols) +
+    scale_fill_manual(values = cols, aesthetics = c("color", "fill")) +
     # Add titles
     ggplot2::ggtitle(paste0(
       gsub("pct_", "", cand_pair[1]), " vs ",

--- a/R/od_plot_create.R
+++ b/R/od_plot_create.R
@@ -47,9 +47,9 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
   names(cols) <- c(gsub("pct_", "", cand_pair[1]), gsub("pct_", "", cand_pair[2]))
 
 
-  densplot <- ggplot2::ggplot(dens_data_sub, ggplot2::aes(x = value, fill = factor(Candidate))) +
+  densplot <- ggplot2::ggplot(dens_data_sub, ggplot2::aes(x = value, fill = Candidate)) +
     # Set colors according to candidate
-    scale_fill_manual(values = cols, aesthetics = c("colour", "fill")) +
+    scale_fill_manual(values = cols) +
     # Add titles
     ggplot2::ggtitle(paste0(
       gsub("pct_", "", cand_pair[1]), " vs ",
@@ -60,7 +60,7 @@ od_plot_create <- function(race, cand_pair, dens_data, out, plot_path = "", cand
     ggplot2::xlab("Percent of vote") +
     ggplot2::ylab("Density") +
     ggplot2::geom_density(
-      alpha = 0.5, ggplot2::aes(x = value * 100, y = ..scaled.., colour = factor(Candidate)),
+      alpha = 0.5, ggplot2::aes(x = value * 100, y = ..scaled.., colour = Candidate),
       adjust = 2
     ) +
     # Add vertical line for halfway


### PR DESCRIPTION
Previously plots exhibited inconsistencies with colors where they were not factored consistently.
Exhibit A:
![pct_husted_pct_button_white](https://user-images.githubusercontent.com/57299524/90591637-74424480-e198-11ea-9939-bcbad7dc8099.png)
Possibilities included outlines differing from fills, and candidates were designated colors but not adhering to those designations.

This was remedied by:
- Updating the factoring process
- Changing the named vector for candidate-color to be atomic 