### PR TITLE
Remove notes in CMD check

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,6 @@
 ^\.pre-commit-config\.yaml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^R/plot\.ei_compare\.R$
+^R/summary\.ei\.R$
+^R/plot\.ei\.R$


### PR DESCRIPTION
This PR is to address the remaining notes in that come up running rcmdcheck or devtools::check(). Feel free to add to this list:

- [ ] Use `.data` to whittle down global bindings.

- [ ] Change unregistered s3s to be normal functions.

- [ ] Fix remaining global function/variable issues.

- [ ] Trim imports.