### PR TITLE
Misc. issue fixes

### DIFF
--- a/R/ei_iter.R
+++ b/R/ei_iter.R
@@ -153,7 +153,6 @@ ei_iter <- function(
     i = seq_len(n_iters),
     .inorder = FALSE,
     .packages = c("ei", "stats", "utils", "mvtnorm"),
-    .export = c("ei_sim", ".samp", "like", ".createR"),
     .options.snow = opts
   ) %myinfix% {
     cand <- race_cand_pairs[i, "cand"]

--- a/R/ei_preprocessing.R
+++ b/R/ei_preprocessing.R
@@ -411,7 +411,7 @@ stdize_votes_all <- function(data,
     race_totals_col <- "cand_totals"
   } else if (is.null(totals_col) & totals_from == "race") {
     if (verbose) {
-      message("Computer totals from race columns...")
+      message("Computing totals from race columns...")
     }
     data$race_totals <- rowSums(data[, race_cols])
     cand_totals_col <- "race_totals"
@@ -437,12 +437,13 @@ stdize_votes_all <- function(data,
     max_dev_cand <- Inf
     avg_dev_race <- Inf
     avg_dev_cand <- Inf
+    verbose = FALSE
   }
 
   if (verbose) {
     message("Standardizing candidate columns...")
   }
-  # Get candidate standardized proportions
+# Get candidate standardized proportions
   cand_prps <- stdize_votes(
     data = data,
     cols = cand_cols,

--- a/R/plot.eiCompare.R
+++ b/R/plot.eiCompare.R
@@ -37,6 +37,12 @@ plot.eiCompare <- function(x, ...) {
   data$race <- factor(data$race, levels = races)
   data$cand <- factor(data$cand, levels = rev(cands))
 
+  # Get errorbars
+  data$lower <- data$mean - data$sd
+  data$upper <- data$mean + data$sd
+  data$lower[data$lower < 0] <- 0
+  data$upper[data$upper > 1] <- 1
+  
   # Construct error bar plot
   ggplot2::ggplot(
     data = data,
@@ -44,8 +50,8 @@ plot.eiCompare <- function(x, ...) {
   ) +
     ggplot2::geom_errorbarh(
       ggplot2::aes(
-        xmin = (.data$mean - .data$sd),
-        xmax = (.data$mean + .data$sd)
+        xmin = .data$lower,
+        xmax = .data$upper
       ),
       height = 0.25,
       position = ggplot2::position_dodge(width = n_objects * 0.25)

--- a/vignettes/ei.Rmd
+++ b/vignettes/ei.Rmd
@@ -37,7 +37,6 @@ options(scipen = 999, digits = 4)
 suppressPackageStartupMessages({
   library(eiCompare)
   library(dplyr)
-  library(doParallel)
 })
 
 data("gwinnett")


### PR DESCRIPTION
### Thanks for opening a PR!

* [X] Have you followed the guidelines in our [Contributing Guide](https://github.com/RPVote/eiCompare/blob/master/CONTRIBUTING.md)?
* [X] Ensured you are not committing large data files or other sensitive information (e.g. voter files)

#### Please list any Issues this PR addresses

- #113 
- #103 
- #102 

#### In 2-3 sentences or a brief list, describe changes implemented in this PR

- `eiCompare plot()` method no longer drops error bars that extend beyond 0 and 1. Instead, they extend up to 0 or 1.
- `stdize_votes_all()` no longer prints messages related to deviation size when `ignore_devs` is set to `TRUE`
- `ei_iter()` bug where setting `par_compute = TRUE` breaks the function has been fixed.
