### PR TITLE
Update ei_rxc.R

### DIFF
--- a/R/ei_rxc.R
+++ b/R/ei_rxc.R
@@ -185,7 +185,7 @@ ei_rxc <- function(
       # Loop through races to get proportion of race voting for each cand
       # This loop is required to get proportions within races
       for (i in 1:length(race_cols)) {
-        race_indices <- grep(race_cols[i], colnames(chains_raw))
+        race_indices <- grep(paste0('\\b',race_cols[i],'\\b'), colnames(chains_raw))
         race_draws <- chains_raw[, race_indices]
         race_pr <- race_draws / rowSums(race_draws)
         chains_pr[, race_indices] <- race_pr
@@ -247,7 +247,7 @@ ei_rxc <- function(
     # Loop through races to get proportion of race voting for each cand
     # This loop is required to get proportions within races
     for (i in 1:length(race_cols)) {
-      race_indices <- grep(race_cols[i], colnames(chains_raw))
+      race_indices <- grep(paste0('\\b',race_cols[i],'\\b'), colnames(chains_raw))
       race_draws <- chains_raw[, race_indices]
       race_pr <- race_draws / rowSums(race_draws)
       chains_pr[, race_indices] <- race_pr


### PR DESCRIPTION
In some rare cases, ei_rxc could mistakenly pull from the wrong race if the names were contained in one another (for example, "latino" and "non_latino".  I added some simple syntax to the grep on lines 188 and 250 to prevent that.


